### PR TITLE
MAINT/FIX: remove density attribute of BayesResult in preparation for V1.0.0

### DIFF
--- a/doc/source/release/0.5.0-notes.rst
+++ b/doc/source/release/0.5.0-notes.rst
@@ -22,6 +22,12 @@ Compatibilities
 Deprecations
 ------------
 
+BayesResult object
+******************
+
+The ``density`` attribute of the :class:`smash.BayesResult` object has been deprecated in preparation for the upcoming release 1.0.0. 
+The other two attributes, ``data`` and ``lcurve``, are still available and can be used for further analysis. 
+
 ------------
 Improvements
 ------------

--- a/doc/source/user_guide/in_depth/optimize/bayes_optimize.rst
+++ b/doc/source/user_guide/in_depth/optimize/bayes_optimize.rst
@@ -130,8 +130,6 @@ It can be implemented using the :class:`smash.Model.bayes_optimize` method as fo
             return_br=True
         )
 
-    model_bo.output.cost  # cost value with HDBC
-
 .. ipython:: python
     :verbatim:
 
@@ -143,6 +141,8 @@ It can be implemented using the :class:`smash.Model.bayes_optimize` method as fo
             options={"maxiter": 4},
             return_br=True
         )
+
+.. ipython:: python
 
     model_bo.output.cost  # cost value with HDBC
 

--- a/smash/core/simulation/bayes_optimize.py
+++ b/smash/core/simulation/bayes_optimize.py
@@ -418,9 +418,8 @@ def _compute_density(
                 u_dis, bw_method=bw_method, weights=weights
             )(u_dis)
 
-            density[p][
-                *zip(*coord)
-            ] = estimted_density  # TODO: add this term in V1.0.0: * getattr(sample, "_" + p) # compute joint probability
+            density[p][*zip(*coord)] = estimted_density
+            # TODO: add this term in V1.0.0: * getattr(sample, "_" + p) # compute joint probability
 
         else:  # Bayes estim (LD-estim)
             density[p][*zip(*coord)] = getattr(sample, "_" + p)

--- a/smash/core/simulation/bayes_optimize.py
+++ b/smash/core/simulation/bayes_optimize.py
@@ -399,16 +399,17 @@ def _compute_density(
     weights: np.ndarray | None,
 ):
     coord = np.dstack([active_mask[0], active_mask[1]])[0]
+    x, y = zip(*coord)
 
     for p in sample._problem["names"]:
         if algorithm == "l-bfgs-b":  # variational Bayes optim (HD-optim)
-            for c in coord:
+            for xi, yi in zip(x, y):
                 estimted_density = gaussian_kde(
-                    data[p][c[0], c[1]], bw_method=bw_method, weights=weights
-                )(data[p][c[0], c[1]])
+                    data[p][xi, yi], bw_method=bw_method, weights=weights
+                )(data[p][xi, yi])
 
                 density[p][
-                    c[0], c[1]
+                    xi, yi
                 ] = estimted_density  # TODO: add this term in V1.0.0: * getattr(sample, "_" + p) # compute joint probability
 
         elif isinstance(algorithm, str):  # global Bayes optim (LD-optim)
@@ -418,11 +419,12 @@ def _compute_density(
                 u_dis, bw_method=bw_method, weights=weights
             )(u_dis)
 
-            density[p][*zip(*coord)] = estimted_density
-            # TODO: add this term in V1.0.0: * getattr(sample, "_" + p) # compute joint probability
+            density[p][
+                x, y
+            ] = estimted_density  # TODO: add this term in V1.0.0: * getattr(sample, "_" + p) # compute joint probability
 
         else:  # Bayes estim (LD-estim)
-            density[p][*zip(*coord)] = getattr(sample, "_" + p)
+            density[p][x, y] = getattr(sample, "_" + p)
 
 
 ### BAYES ESTIMATE AND L-CURVE


### PR DESCRIPTION
- Enhancements/Fixes for bayes_optimize:
  - remove density attribute in preparation for V1.0.0, which will be integrated by a joint probability
  - remove unnecessary numpy copy for optimizing computational memory
  - enhance loop of assigning values to distributed map for optimizing computational time
 - Fix cost not displayed in user guide Bayesian optimization
 - Update release note