### PR TITLE
FIX: max_duration event segmentation algorithm

### DIFF
--- a/doc/source/math_num_documentation/signal_analysis/hydrograph_segmentation.rst
+++ b/doc/source/math_num_documentation/signal_analysis/hydrograph_segmentation.rst
@@ -59,6 +59,5 @@ For :math:`t_{j}\in E`:
 .. note::
  
     If there exists :math:`m+1` :math:`(m>0)` consecutive events :math:`(sd_{u},ed_{u}),...,(sd_{u+m},ed_{u+m})` 
-    occurring "nearly simultaneously", that means all of these events 
-    occur in no more than ``max_duration`` hours: :math:`ed_{u+m}<sd_{u}+` ``max_duration``, then we 
-    merge these :math:`m+1` events into a single event :math:`(sd_{u},ed_{u+m})`.
+    occurring "nearly simultaneously", then we merge these :math:`m+1` events into a single event :math:`(sd_{u},ed_{u+m})`. 
+    Note that the duration of the merged event may exceed the specified maximum duration of ``max_duration`` hours.

--- a/doc/source/release/0.5.0-notes.rst
+++ b/doc/source/release/0.5.0-notes.rst
@@ -87,6 +87,11 @@ The bug related to the computation of flood event signatures has been resolved f
 
 See issue `#28 <https://github.com/DassHydro-dev/smash/issues/28>`__.
 
+Segmentation algorithm
+**********************
+
+If multiple events are detected, the duration of the merged event is no longer constrained by the max duration parameter. Instead, its duration may exceed this value.
+
 ``smash.generate_mesh`` segmentation fault
 ******************************************
 

--- a/smash/core/_event_segmentation.py
+++ b/smash/core/_event_segmentation.py
@@ -267,9 +267,10 @@ def _events_grad(
             prev_peakq = list_events[-1]["peakQ"]
             prev_peakp = list_events[-1]["peakP"]
 
-            # % merge two events respecting to max duration:
-            if max(end, prev_end) <= prev_start + max_duration:
+            # % detect double events:
+            if prev_end >= start:
                 list_events[-1]["end"] = max(end, prev_end)
+                list_events[-1]["start"] = min(start, prev_start)
 
                 if q[i_peak] > q[prev_peakq]:
                     list_events[-1]["peakQ"] = i_peak

--- a/smash/core/model.py
+++ b/smash/core/model.py
@@ -1441,7 +1441,7 @@ class Model(object):
             Events will be selected if their discharge peaks exceed the **peak_quant**-quantile of the observed discharge timeseries.
 
         max_duration: float, default 240
-            The expected maximum duration of an event (in hour).
+            The expected maximum duration of an event (in hours). If multiple events are detected, their duration may exceed this value.
 
         Returns
         -------


### PR DESCRIPTION
Fix segmentation algorithm:

- If multiple events are detected, the duration of the merged event is no longer constrained by the max duration parameter. Instead, its duration may exceed this value.
