### PR TITLE
Fix : When the rainfall data is spatially desagregated, a temporary n…

### DIFF
--- a/doc/source/release/0.5.0-notes.rst
+++ b/doc/source/release/0.5.0-notes.rst
@@ -99,3 +99,11 @@ An error occured when two neighboring cells have antagonistic flow directions ``
 segmentation faults when the maximum number of recursions has been reached, a check is added to the code to exit recursion in that case.
 
 See issue `#31 <https://github.com/DassHydro-dev/smash/issues/31>`__.
+
+Correctly handle Nodata value during the spatial desagregation of the rainfall
+******************************************************************************
+
+A crash occured during the desagregation of th rainfall. The creation of a GDAL virtual-destination failed when the parent geotiff file has its Nodata value unset (None type). When this is the case, the Nodata value of the desagregated rainfall is automatically set to -99.
+
+see issue `#36 https://github.com/DassHydro-dev/smash/pull/36/commits/9c760201ff0590f0e8ef38314b16b0b0932366f1>`__.
+

--- a/doc/source/release/0.5.0-notes.rst
+++ b/doc/source/release/0.5.0-notes.rst
@@ -100,10 +100,9 @@ segmentation faults when the maximum number of recursions has been reached, a ch
 
 See issue `#31 <https://github.com/DassHydro-dev/smash/issues/31>`__.
 
-Correctly handle Nodata value during the spatial desagregation of the rainfall
-******************************************************************************
+Correctly handle Nodata value during the spatial disaggregation of the rainfall
+*******************************************************************************
 
-A crash occured during the desagregation of th rainfall. The creation of a GDAL virtual-destination failed when the parent geotiff file has its Nodata value unset (None type). When this is the case, the Nodata value of the desagregated rainfall is automatically set to -99.
+A crash occured during the disaggregation of the rainfall. The creation of a GDAL virtual-destination failed when the parent geotiff file has its Nodata value unset (None type). When this is the case, the Nodata value of the disaggregation rainfall is automatically set to -99.
 
-see issue `#36 https://github.com/DassHydro-dev/smash/pull/36/commits/9c760201ff0590f0e8ef38314b16b0b0932366f1>`__.
-
+See issue `#40 <https://github.com/DassHydro-dev/smash/issues/40>`__.

--- a/smash/tools/raster_handler.py
+++ b/smash/tools/raster_handler.py
@@ -146,10 +146,14 @@ def gdal_reproject_raster(dataset, xres, yres):
     # Workaround for gdal bug which initialise array to 0 instead as the No_Data value
     # Here we initialise the band manually with the nodata_value
     nodata = dataset.GetRasterBand(1).GetNoDataValue()
+    if not isinstance(nodata,float):
+        nodata=-99.
+
     band = virtual_destination.GetRasterBand(
         1
     )  # Notice that band is a pointer to virtual_destination
-    band.SetNoDataValue(nodata)
+    band.SetNoDataValue(nodata) #nodata argument of type 'double'
+
     nodataarray = np.ndarray(shape=(new_y_size, new_x_size))
     nodataarray.fill(nodata)
     band.WriteArray(nodataarray)

--- a/smash/tools/raster_handler.py
+++ b/smash/tools/raster_handler.py
@@ -31,7 +31,7 @@ def gdal_raster_open(filename):
     --------
     dataset = gdal_raster_open("filename")
     """
-    
+
     if os.path.isfile(filename):
         dataset = gdal.Open(filename)
     else:
@@ -146,13 +146,13 @@ def gdal_reproject_raster(dataset, xres, yres):
     # Workaround for gdal bug which initialise array to 0 instead as the No_Data value
     # Here we initialise the band manually with the nodata_value
     nodata = dataset.GetRasterBand(1).GetNoDataValue()
-    if not isinstance(nodata,float):
-        nodata=-99.
+    if not isinstance(nodata, float):
+        nodata = -99.0
 
     band = virtual_destination.GetRasterBand(
         1
     )  # Notice that band is a pointer to virtual_destination
-    band.SetNoDataValue(nodata) #nodata argument of type 'double'
+    band.SetNoDataValue(nodata)  # nodata argument of type 'double'
 
     nodataarray = np.ndarray(shape=(new_y_size, new_x_size))
     nodataarray.fill(nodata)
@@ -395,7 +395,7 @@ def union_bbox(bbox1, bbox2):
     ----------
     bbox1: dict containin the first bbox informations
     bbox2 : dict containin the second bbox informations
-    
+
     returns
     -------
     dic containing the bbox union
@@ -423,7 +423,7 @@ def get_bbox(dataset):
     Parameters
     ----------
     dataset: gdal object
-    
+
     returns
     -------
     dic containing the bbox of the dataset
@@ -451,7 +451,7 @@ def get_bbox_from_window(dataset, window):
     ----------
     dataset: gdal object
     window : dict with ncol, nrow, col offset and row offset
-    
+
     returns
     -------
     dic containing the computed bbox
@@ -482,7 +482,7 @@ def get_window_from_bbox(dataset, bbox):
     ----------
     dataset: gdal object
     bbox : dict containing the bbox
-    
+
     returns
     -------
     dic containing the computed windows
@@ -525,7 +525,7 @@ def crop_array(array, window):
     ----------
     array: numpy array
     window : dict containg the window to crop
-    
+
     returns
     -------
     crop_array: the cropped numpy array, shape of the defined window


### PR DESCRIPTION
…ew raster geotiff is generated. We guess the no data value using the input raster. However, if nodata value was set toi None type, the setter "_setNoDataValue" crash. Indeed arguments must be a double type only. Thus We know check if the guessed nodata value is an instance of float, else we set nodata value to -99.0