### PR TITLE
Fix some bugs in smash.io

### DIFF
--- a/doc/source/release/0.5.1-notes.rst
+++ b/doc/source/release/0.5.1-notes.rst
@@ -6,17 +6,13 @@
 smash 0.5.1 Release Notes
 =========================
 
-The smash 0.5.1 fix bugs and clarify the documentation.
+The smash 0.5.1 release continues the ongoing work to improve the handling, fix possible bugs, clarify the documentation. The highlights are:
 
 ------------
 Contributors
 ------------
 
 This release was made possible thanks to the contributions of:
-
-- Maxime Jay-Allemand
-- Ngo Nghi Truyen Huynh
-- François Colleoni
 
 ------------
 Deprecations
@@ -26,10 +22,10 @@ Deprecations
 Improvements
 ------------
 
-Missing documentation API for functions hdf5_handler, hdf5_io and object_handler
-********************************************************************************
+Documentation
+*************
 
-The documentation API was missing for the new functions for reading and writting hdf5 files added in release 0.5.0. This has been corrected. `#46 <https://github.com/DassHydro-dev/smash/issues/46`
+Improvement of the API section for new functions created in the previous release, including :class:`smash.tools.hdf5_handler`, :class:`smash.io.hdf5_io` and :class:`smash.tools.object_handler`.
 
 ------------
 New Features
@@ -39,9 +35,16 @@ New Features
 Fixes
 -----
 
-Missing interception parameters ci in constant parameters
-*********************************************************
+Missing interception parameter ci in constant parameters
+********************************************************
 
-Ci was missing in the parameter constant list and can't be saved and post processed or retrieved at all. This is fixed now. `#46 <https://github.com/DassHydro-dev/smash/issues/45`
+The interception parameter **ci** has been added to the list of constant parameters.
 
+See issue `#45 <https://github.com/DassHydro-dev/smash/issues/45>`__.
 
+Saving mesh
+***********
+
+Fixed a bug that caused issues when saving a mesh whose catchment code was loaded from a pandas dataframe.
+
+See issue `#53 <https://github.com/DassHydro-dev/smash/issues/53>`__.

--- a/smash/io/mesh_io.py
+++ b/smash/io/mesh_io.py
@@ -14,7 +14,7 @@ __all__ = ["save_mesh", "read_mesh"]
 def _parse_mesh_dict_to_hdf5(mesh: dict, hdf5_ins):
     for key, value in mesh.items():
         if isinstance(value, np.ndarray):
-            if value.dtype.char == "U":
+            if value.dtype == "object" or value.dtype.char == "U":
                 value = value.astype("S")
 
             hdf5_ins.create_dataset(

--- a/smash/tools/hdf5_handler.py
+++ b/smash/tools/hdf5_handler.py
@@ -4,7 +4,7 @@ import os
 import h5py
 import numpy as np
 
-from smash.tools import object_handler
+from smash.tools.object_handler import generate_object_structure
 
 
 def open_hdf5(path, read_only=False, replace=False):
@@ -358,7 +358,7 @@ def save_object_to_hdf5(
     """
 
     if keys_data is None:
-        keys_data = object_handler.generate_object_structure(instance)
+        keys_data = generate_object_structure(instance)
 
     hdf5 = open_hdf5(f_hdf5, replace=replace)
     hdf5 = add_hdf5_sub_group(hdf5, subgroup=location)

--- a/smash/tools/hdf5_handler.py
+++ b/smash/tools/hdf5_handler.py
@@ -358,7 +358,7 @@ def save_object_to_hdf5(
     """
 
     if keys_data is None:
-        keys_data = smash.tools.object_handler.generate_object_structure(instance)
+        keys_data = object_handler.generate_object_structure(instance)
 
     hdf5 = open_hdf5(f_hdf5, replace=replace)
     hdf5 = add_hdf5_sub_group(hdf5, subgroup=location)


### PR DESCRIPTION
- Fix bug on saving mesh
- Fix minor bug on hdf5_handler:
```python3
keys_data = smash.tools.object_handler.generate_object_structure(instance)
```
smash was not previously imported!

- Update release notes.