### PR TITLE
MAINT: Remove cost_variant from model simulation Python interface

### DIFF
--- a/smash/_constant.py
+++ b/smash/_constant.py
@@ -258,8 +258,6 @@ PROBLEM_KEYS = ["num_vars", "names", "bounds"]
 
 MAPPING = ["uniform", "distributed", "multi-linear", "multi-polynomial", "ann"]
 
-COST_VARIANT = ["cls", "bys"]
-
 F90_OPTIMIZER = ["sbs", "lbfgsb"]
 
 OPTIMIZER = F90_OPTIMIZER + PY_OPTIMIZER
@@ -362,34 +360,16 @@ SIMULATION_OPTIMIZE_OPTIONS_KEYS = {
     ),
 }
 
-# % Following COST_VARIANT order
-DEFAULT_SIMULATION_COST_OPTIONS = dict(
-    zip(
-        COST_VARIANT,
-        [
-            {
-                "jobs_cmpt": "nse",
-                "wjobs_cmpt": "mean",
-                "wjreg": 0,
-                "jreg_cmpt": None,
-                "wjreg_cmpt": "mean",
-                "gauge": "dws",
-                "wgauge": "mean",
-                "event_seg": None,
-                "end_warmup": None,
-            },
-            {
-                "jobs_cmpt": "lklhd",
-                "wjobs_cmpt": "mean",
-                "wjreg": 0,
-                "jreg_cmpt": None,
-                "wjreg_cmpt": "mean",
-                "gauge": "dws",
-                "event_seg": None,
-                "end_warmup": None,
-            },
-        ],
-    )
-)
+DEFAULT_SIMULATION_COST_OPTIONS = {
+    "jobs_cmpt": "nse",
+    "wjobs_cmpt": "mean",
+    "wjreg": 0,
+    "jreg_cmpt": None,
+    "wjreg_cmpt": "mean",
+    "gauge": "dws",
+    "wgauge": "mean",
+    "event_seg": None,
+    "end_warmup": None,
+}
 
 DEFAULT_SIMULATION_COMMON_OPTIONS = {"ncpu": 1, "verbose": True}

--- a/smash/core/model/model.py
+++ b/smash/core/model/model.py
@@ -219,20 +219,18 @@ class Model(object):
 
     def forward_run(
         self,
-        cost_variant: str = "cls",
         cost_options: dict | None = None,
         common_options: dict | None = None,
     ):
         args_options = [deepcopy(arg) for arg in [cost_options, common_options]]
 
-        args = _standardize_forward_run_args(self, cost_variant, *args_options)
+        args = _standardize_forward_run_args(self, *args_options)
 
         _forward_run(self, *args)
 
     def optimize(
         self,
         mapping: str = "uniform",
-        cost_variant: str = "cls",
         optimizer: str | None = None,
         optimize_options: dict | None = None,
         cost_options: dict | None = None,
@@ -245,7 +243,6 @@ class Model(object):
         args = _standardize_optimize_args(
             self,
             mapping,
-            cost_variant,
             optimizer,
             *args_options,
         )

--- a/smash/core/simulation/estimate/_tools.py
+++ b/smash/core/simulation/estimate/_tools.py
@@ -104,7 +104,6 @@ def _estimate_parameter(
 def _forward_run_with_estimated_parameters(
     alpha: float,
     model: Model,
-    cost_variant: str,
     cost_options: dict,
     prior_data: dict,
     density: dict,
@@ -131,7 +130,6 @@ def _forward_run_with_estimated_parameters(
         mahal_distance += distance_p
 
     model.forward_run(
-        cost_variant=cost_variant,
         cost_options=cost_options,
         common_options={"verbose": False, "ncpu": ncpu},
     )

--- a/smash/core/simulation/estimate/estimate.py
+++ b/smash/core/simulation/estimate/estimate.py
@@ -86,7 +86,6 @@ def _multiset_estimate(
     estimator(
         alpha,
         model,
-        multiset._cost_variant,
         multiset._cost_options,
         prior_data,
         density,

--- a/smash/core/simulation/optimize/_standardize.py
+++ b/smash/core/simulation/optimize/_standardize.py
@@ -4,7 +4,6 @@ from smash.core.simulation._standardize import (
     _standardize_simulation_samples,
     _standardize_simulation_mapping,
     _standardize_simulation_optimizer,
-    _standardize_simulation_cost_variant,
     _standardize_simulation_optimize_options,
     _standardize_simulation_cost_options,
     _standardize_simulation_common_options,
@@ -26,7 +25,6 @@ if TYPE_CHECKING:
 def _standardize_optimize_args(
     model: Model,
     mapping: str,
-    cost_variant: str,
     optimizer: str | None,
     optimize_options: dict | None,
     cost_options: dict | None,
@@ -37,17 +35,13 @@ def _standardize_optimize_args(
 
     mapping = _standardize_simulation_mapping(mapping)
 
-    cost_variant = _standardize_simulation_cost_variant(cost_variant)
-
     optimizer = _standardize_simulation_optimizer(mapping, optimizer)
 
     optimize_options = _standardize_simulation_optimize_options(
         model, mapping, optimizer, optimize_options
     )
 
-    cost_options = _standardize_simulation_cost_options(
-        model, cost_variant, cost_options
-    )
+    cost_options = _standardize_simulation_cost_options(model, cost_options)
 
     common_options = _standardize_simulation_common_options(common_options)
 
@@ -57,11 +51,10 @@ def _standardize_optimize_args(
     )
 
     # % Finalize cost_options
-    _standardize_simulation_cost_options_finalize(model, cost_variant, cost_options)
+    _standardize_simulation_cost_options_finalize(model, cost_options)
 
     return (
         mapping,
-        cost_variant,
         optimizer,
         optimize_options,
         cost_options,
@@ -73,7 +66,6 @@ def _standardize_multiple_optimize_args(
     model: Model,
     samples: Samples,
     mapping: str,
-    cost_variant: str,
     optimizer: str | None,
     optimize_options: dict | None,
     cost_options: dict | None,
@@ -86,17 +78,13 @@ def _standardize_multiple_optimize_args(
 
     mapping = _standardize_multiple_optimize_mapping(mapping)
 
-    cost_variant = _standardize_simulation_cost_variant(cost_variant)
-
     optimizer = _standardize_simulation_optimizer(mapping, optimizer)
 
     optimize_options = _standardize_simulation_optimize_options(
         model, mapping, optimizer, optimize_options
     )
 
-    cost_options = _standardize_simulation_cost_options(
-        model, cost_variant, cost_options
-    )
+    cost_options = _standardize_simulation_cost_options(model, cost_options)
 
     common_options = _standardize_simulation_common_options(common_options)
 
@@ -106,12 +94,11 @@ def _standardize_multiple_optimize_args(
     )
 
     # % Finalize cost_options
-    _standardize_simulation_cost_options_finalize(model, cost_variant, cost_options)
+    _standardize_simulation_cost_options_finalize(model, cost_options)
 
     return (
         samples,
         mapping,
-        cost_variant,
         optimizer,
         optimize_options,
         cost_options,

--- a/smash/core/simulation/optimize/optimize.py
+++ b/smash/core/simulation/optimize/optimize.py
@@ -71,7 +71,6 @@ class MultipleOptimize(dict):
 def optimize(
     model: Model,
     mapping: str = "uniform",
-    cost_variant: str = "cls",
     optimizer: str | None = None,
     optimize_options: dict | None = None,
     cost_options: dict | None = None,
@@ -79,9 +78,7 @@ def optimize(
 ):
     wmodel = model.copy()
 
-    wmodel.optimize(
-        mapping, cost_variant, optimizer, optimize_options, cost_options, common_options
-    )
+    wmodel.optimize(mapping, optimizer, optimize_options, cost_options, common_options)
 
     return wmodel
 
@@ -89,7 +86,6 @@ def optimize(
 def _optimize(
     model: Model,
     mapping: str,
-    cost_variant: str,
     optimizer: str,
     optimize_options: dict,
     cost_options: dict,
@@ -221,7 +217,6 @@ def multiple_optimize(
     model: Model,
     samples: Samples,
     mapping: str = "uniform",
-    cost_variant: str = "cls",
     optimizer: str | None = None,
     optimize_options: dict | None = None,
     cost_options: dict | None = None,
@@ -235,7 +230,6 @@ def multiple_optimize(
         model,
         samples,
         mapping,
-        cost_variant,
         optimizer,
         *args_options,
     )
@@ -252,7 +246,6 @@ def _multiple_optimize(
     model: Model,
     samples: Samples,
     mapping: str,
-    cost_variant: str,
     optimizer: str,
     optimize_options: dict,
     cost_options: dict,
@@ -391,5 +384,4 @@ def _multiple_optimize(
         "q": q,
         "parameters": parameters,
         "_samples": samples_fnl,
-        "_cost_variant": cost_variant,
     }

--- a/smash/core/simulation/options.py
+++ b/smash/core/simulation/options.py
@@ -4,7 +4,6 @@ from smash.core.simulation._standardize import (
     _standardize_simulation_optimize_options,
     _standardize_simulation_cost_options,
     _standardize_default_optimize_options_args,
-    _standardize_default_cost_options_args,
 )
 
 from typing import TYPE_CHECKING
@@ -27,11 +26,5 @@ def default_optimize_options(
 
 
 # % TODO: add docstring - this function is used for creating and the documentation of cost_options in model.optimize()
-# % Future TODO: cost_options depending on (mapping, cost_variant) instead of cost_variant
-def default_cost_options(
-    model: Model,
-    cost_variant: str = "cls",
-) -> dict:
-    cost_variant = _standardize_default_cost_options_args(cost_variant)
-
-    return _standardize_simulation_cost_options(model, cost_variant, None)
+def default_cost_options(model: Model) -> dict:
+    return _standardize_simulation_cost_options(model, None)

--- a/smash/core/simulation/run/_standardize.py
+++ b/smash/core/simulation/run/_standardize.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from smash.core.simulation._standardize import (
     _standardize_simulation_samples,
-    _standardize_simulation_cost_variant,
     _standardize_simulation_cost_options,
     _standardize_simulation_common_options,
     _standardize_simulation_parameters_feasibility,
@@ -19,38 +18,32 @@ if TYPE_CHECKING:
 
 def _standardize_forward_run_args(
     model: Model,
-    cost_variant: str,
     cost_options: dict | None,
     common_options: dict | None,
 ) -> AnyTuple:
     # % In case model.set_opr_parameters or model.set_opr_initial_states were not used
     _standardize_simulation_parameters_feasibility(model)
 
-    cost_variant = _standardize_simulation_cost_variant(cost_variant)
-
-    cost_options = _standardize_simulation_cost_options(
-        model, cost_variant, cost_options
-    )
+    cost_options = _standardize_simulation_cost_options(model, cost_options)
 
     common_options = _standardize_simulation_common_options(common_options)
 
     # % Finalize cost_options
-    _standardize_simulation_cost_options_finalize(model, cost_variant, cost_options)
+    _standardize_simulation_cost_options_finalize(model, cost_options)
 
-    return (cost_variant, cost_options, common_options)
+    return (cost_options, common_options)
 
 
 def _standardize_multiple_forward_run_args(
     model: Model,
     samples: Samples,
-    cost_variant: str,
     cost_options: dict | None,
     common_options: dict | None,
 ) -> AnyTuple:
     samples = _standardize_simulation_samples(model, samples)
 
     forward_run_args = _standardize_forward_run_args(
-        model, cost_variant, cost_options, common_options
+        model, cost_options, common_options
     )
 
     return (samples, *forward_run_args)

--- a/smash/core/simulation/run/run.py
+++ b/smash/core/simulation/run/run.py
@@ -69,20 +69,17 @@ class MultipleForwardRun(dict):
 
 def forward_run(
     model: Model,
-    cost_variant: str = "cls",
     cost_options: dict | None = None,
     common_options: dict | None = None,
 ) -> Model:
     wmodel = model.copy()
 
-    wmodel.forward_run(cost_variant, cost_options, common_options)
+    wmodel.forward_run(cost_options, common_options)
 
     return wmodel
 
 
-def _forward_run(
-    model: Model, cost_variant: str, cost_options: dict, common_options: dict
-):
+def _forward_run(model: Model, cost_options: dict, common_options: dict):
     if common_options["verbose"]:
         print("</> Forward Run")
 
@@ -120,15 +117,12 @@ def _forward_run(
 def multiple_forward_run(
     model: Model,
     samples: Samples,
-    cost_variant: str = "cls",
     cost_options: dict | None = None,
     common_options: dict | None = None,
 ) -> MultipleForwardRun:
     args_options = [deepcopy(arg) for arg in [cost_options, common_options]]
 
-    args = _standardize_multiple_forward_run_args(
-        model, samples, cost_variant, *args_options
-    )
+    args = _standardize_multiple_forward_run_args(model, samples, *args_options)
 
     res = _multiple_forward_run(model, *args)
 
@@ -141,7 +135,6 @@ def multiple_forward_run(
 def _multiple_forward_run(
     model: Model,
     samples: Samples,
-    cost_variant: str,
     cost_options: dict,
     common_options: dict,
 ) -> dict:
@@ -210,4 +203,4 @@ def _multiple_forward_run(
         q,
     )
 
-    return {"cost": cost, "q": q, "_samples": samples, "_cost_variant": cost_variant}
+    return {"cost": cost, "q": q, "_samples": samples}


### PR DESCRIPTION
Remove cost_variant parameter from simulation functions in Python.