### PR TITLE
ENC: Start API documentation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -28,4 +28,4 @@ clean:
 	@rm -rf $(BUILDDIR)
 	@rm -rf $(SOURCEDIR)/savefig
 	@rm -rf *.hdf5 *yaml
-	@rm -rf $(SOURCEDIR)/api_reference/smash
+	@find $(SOURCEDIR)/api_reference/ -type d -name "smash" -exec rm -rf {} +

--- a/doc/source/_ext/custom_options_directive.py
+++ b/doc/source/_ext/custom_options_directive.py
@@ -30,9 +30,9 @@ def _option_required_str(x):
 def _import_object_interface(name):
     parts = name.split(".")
     if parts[0] == "Model":
-        module_name = "smash.core.model.Model"
+        module_name = "smash.core.model.model.Model"
     elif parts[0] == "Net":
-        module_name = "smash.core.net.Net"
+        module_name = "smash.factory.net.net.Net"
     else:
         raise ValueError(f"Unknown object interface {name}")
     obj = getattr(eval(module_name), parts[-1])

--- a/doc/source/api_reference/index.rst
+++ b/doc/source/api_reference/index.rst
@@ -3,3 +3,33 @@
 =============
 API Reference
 =============
+
+This page gives an overview of all public `smash` objects, functions and methods.
+
+Principal Methods
+*****************
+.. toctree::
+   :maxdepth: 2
+
+   principal_methods/model
+   principal_methods/simulation
+   principal_methods/signal_analysis
+
+Sub-packages
+************
+.. toctree::
+    :maxdepth: 2
+
+    sub-packages/factory
+    sub-packages/io
+
+Returned Objects
+****************
+.. toctree::
+    :maxdepth: 1
+
+    returned_objects/signatures
+    returned_objects/precipitation_indices
+    returned_objects/samples
+    returned_objects/multiple_forward_run
+    returned_objects/multiple_optimize

--- a/doc/source/api_reference/principal_methods/model.rst
+++ b/doc/source/api_reference/principal_methods/model.rst
@@ -1,0 +1,52 @@
+.. _api_reference.principal_methods.model:
+
+=====
+Model
+=====
+
+.. currentmodule:: smash
+
+Constructor
+***********
+.. autosummary::
+   :toctree: smash/
+   
+   Model
+   Model.copy
+   
+Attributes
+**********
+.. autosummary::
+   :toctree: smash/
+
+   Model.setup
+   Model.mesh
+   Model.obs_response
+   Model.physio_data
+   Model.atmos_data
+   Model.opr_parameters
+   Model.opr_initial_states
+   Model.sim_response
+   Model.opr_final_states
+   
+Simulation
+**********
+.. autosummary::
+   :toctree: smash/
+
+   Model.forward_run
+   Model.optimize
+   Model.multiset_estimate
+
+Parameters/States
+*****************
+.. autosummary::
+   :toctree: smash/
+
+   Model.get_opr_parameters
+   Model.get_opr_initial_states
+   Model.get_opr_final_states
+   Model.set_opr_parameters
+   Model.set_opr_initial_states
+   Model.get_opr_parameters_bounds
+   Model.get_opr_initial_states_bounds

--- a/doc/source/api_reference/principal_methods/signal_analysis.rst
+++ b/doc/source/api_reference/principal_methods/signal_analysis.rst
@@ -1,0 +1,35 @@
+.. _api_reference.principal_methods.signal_analysis:
+
+===============
+Signal Analysis
+===============
+
+.. currentmodule:: smash
+
+Hydrograph Segmentation
+***********************
+.. autosummary::
+      :toctree: smash/
+
+      hydrograph_segmentation
+
+Hydrological Signatures
+***********************
+.. autosummary::
+      :toctree: smash/
+
+      signatures
+
+Precipitation Indices
+*********************
+.. autosummary::
+      :toctree: smash/
+
+      precipitation_indices
+
+Evaluation Metrics
+******************
+.. autosummary::
+      :toctree: smash/
+
+      metrics

--- a/doc/source/api_reference/principal_methods/simulation.rst
+++ b/doc/source/api_reference/principal_methods/simulation.rst
@@ -1,0 +1,50 @@
+.. _api_reference.principal_methods.simulation:
+
+==========
+Simulation
+==========
+
+.. currentmodule:: smash
+
+Forward Run
+***********
+.. autosummary::
+      :toctree: smash/
+
+      forward_run
+
+Optimize
+********
+.. autosummary::
+      :toctree: smash/
+
+      optimize
+
+Multiple Forward Run
+********************
+.. autosummary::
+      :toctree: smash/
+
+      multiple_forward_run
+
+Multiple Optimize
+*****************
+.. autosummary::
+      :toctree: smash/
+
+      multiple_optimize
+
+Multiset Estimate
+*****************
+.. autosummary::
+      :toctree: smash/
+
+      multiset_estimate
+
+Default Options
+*****************
+.. autosummary::
+      :toctree: smash/
+
+      default_optimize_options
+      default_cost_options

--- a/doc/source/api_reference/returned_objects/multiple_forward_run.rst
+++ b/doc/source/api_reference/returned_objects/multiple_forward_run.rst
@@ -1,0 +1,12 @@
+.. _api_reference.returned_objects.multiple_forward_run:
+
+====================
+Multiple Forward Run
+====================
+
+.. currentmodule:: smash
+
+.. autosummary::
+      :toctree: smash/
+
+      MultipleForwardRun

--- a/doc/source/api_reference/returned_objects/multiple_optimize.rst
+++ b/doc/source/api_reference/returned_objects/multiple_optimize.rst
@@ -1,0 +1,12 @@
+.. _api_reference.returned_objects.multiple_optimize:
+
+=================
+Multiple Optimize
+=================
+
+.. currentmodule:: smash
+
+.. autosummary::
+      :toctree: smash/
+
+      MultipleOptimize

--- a/doc/source/api_reference/returned_objects/precipitation_indices.rst
+++ b/doc/source/api_reference/returned_objects/precipitation_indices.rst
@@ -1,0 +1,12 @@
+.. _api_reference.returned_objects.precipitation_indices:
+
+=====================
+Precipitation Indices
+=====================
+
+.. currentmodule:: smash
+
+.. autosummary::
+      :toctree: smash/
+
+      PrecipitationIndices

--- a/doc/source/api_reference/returned_objects/samples.rst
+++ b/doc/source/api_reference/returned_objects/samples.rst
@@ -1,0 +1,12 @@
+.. _api_reference.returned_objects.samples:
+
+=======
+Samples
+=======
+
+.. currentmodule:: smash
+
+.. autosummary::
+      :toctree: smash/
+
+      Samples

--- a/doc/source/api_reference/returned_objects/signatures.rst
+++ b/doc/source/api_reference/returned_objects/signatures.rst
@@ -1,0 +1,12 @@
+.. _api_reference.returned_objects.signatures:
+
+==========
+Signatures
+==========
+
+.. currentmodule:: smash
+
+.. autosummary::
+      :toctree: smash/
+
+      Signatures

--- a/doc/source/api_reference/sub-packages/factory.rst
+++ b/doc/source/api_reference/sub-packages/factory.rst
@@ -1,0 +1,38 @@
+.. _api_reference.sub-packages.factory:
+
+=======
+Factory
+=======
+
+.. currentmodule:: smash.factory
+
+This sub-package provides methods for creating essential elements, that are utilized by the Model object without requiring its prior instantiation.
+
+Dataset Loading
+***************
+.. autosummary::
+      :toctree: smash/
+
+      load_dataset
+
+Mesh Generation
+***************
+.. autosummary::
+      :toctree: smash/
+
+      generate_mesh
+
+Neural Network Configuration
+****************************
+.. toctree::
+   :maxdepth: 2
+   
+   net/index
+
+Sample Generation
+*****************
+.. autosummary::
+      :toctree: smash/
+
+      generate_samples
+

--- a/doc/source/api_reference/sub-packages/io.rst
+++ b/doc/source/api_reference/sub-packages/io.rst
@@ -1,0 +1,33 @@
+.. _api_reference.sub-packages.io:
+
+===========
+Input/Ouput
+===========
+
+.. currentmodule:: smash.io
+
+This sub-package provides methods for handling input and output operations related to data objects.
+
+Model
+*****
+.. autosummary::
+      :toctree: smash/
+
+      save_model
+      read_model
+
+Mesh
+****
+.. autosummary::
+      :toctree: smash/
+
+      save_mesh
+      read_mesh
+
+Setup
+*****
+.. autosummary::
+      :toctree: smash/
+
+      save_setup
+      read_setup

--- a/doc/source/api_reference/sub-packages/net/add_activation.rst
+++ b/doc/source/api_reference/sub-packages/net/add_activation.rst
@@ -1,0 +1,10 @@
+.. _api_reference.sub-packages.net.add_activation:
+
+add(layer='activation')
+-----------------------
+
+.. currentmodule:: smash.factory
+
+.. smash-net-add:function:: Net.add
+   :noindex:
+   :impl: smash.factory.net.net.Activation

--- a/doc/source/api_reference/sub-packages/net/add_dense.rst
+++ b/doc/source/api_reference/sub-packages/net/add_dense.rst
@@ -1,0 +1,10 @@
+.. _api_reference.sub-packages.net.add_dense:
+
+add(layer='dense')
+-----------------------
+
+.. currentmodule:: smash.factory
+
+.. smash-net-add:function:: Net.add
+   :noindex:
+   :impl: smash.factory.net.net.Dense

--- a/doc/source/api_reference/sub-packages/net/add_dropout.rst
+++ b/doc/source/api_reference/sub-packages/net/add_dropout.rst
@@ -1,0 +1,10 @@
+.. _api_reference.sub-packages.net.add_dropout:
+
+add(layer='dropout')
+-----------------------
+
+.. currentmodule:: smash.factory
+
+.. smash-net-add:function:: Net.add
+   :noindex:
+   :impl: smash.factory.net.net.Dropout

--- a/doc/source/api_reference/sub-packages/net/add_scale.rst
+++ b/doc/source/api_reference/sub-packages/net/add_scale.rst
@@ -1,0 +1,10 @@
+.. _api_reference.sub-packages.net.add_scale:
+
+add(layer='scale')
+-----------------------
+
+.. currentmodule:: smash.factory
+
+.. smash-net-add:function:: Net.add
+   :noindex:
+   :impl: smash.factory.net.net.Scale

--- a/doc/source/api_reference/sub-packages/net/index.rst
+++ b/doc/source/api_reference/sub-packages/net/index.rst
@@ -1,0 +1,44 @@
+.. _api_reference.sub-packages.net:
+
+===
+Net
+===
+
+.. currentmodule:: smash.factory
+
+Constructor
+***********
+.. autosummary::
+   :toctree: smash/
+   
+   Net
+   Net.copy
+
+Attributes
+**********
+.. autosummary::
+   :toctree: smash/
+
+   Net.layers
+   Net.history
+
+Methods
+*******
+.. autosummary::
+   :toctree: smash/
+
+   Net.add
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   add_dense
+   add_activation
+   add_scale
+   add_dropout
+
+.. autosummary::
+   :toctree: smash/
+
+   Net.set_trainable

--- a/doc/source/gen_rst.py
+++ b/doc/source/gen_rst.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
             + ":"
         )
 
-    rst_main_title = file_path.stem.replace("_", " ").capitalize()
+    rst_main_title = ' '.join(word.capitalize() for word in file_path.stem.split('_'))
     len_rst_main_title = len(rst_main_title)
 
     with open(file_path, "w") as f:

--- a/smash/core/model/model.py
+++ b/smash/core/model/model.py
@@ -52,6 +52,38 @@ __all__ = ["Model"]
 
 
 class Model(object):
+        
+    """
+    Primary data structure of the hydrological model `smash`.
+
+    Parameters
+    ----------
+    setup : dict
+        Model initialization setup dictionary (TODO: add reference).
+
+    mesh : dict
+        Model initialization mesh dictionary (TODO: add reference).
+
+    See Also
+    --------
+    smash.io.save_model : Save the Model object.
+    smash.io.read_model : Read the Model object.
+    smash.io.save_setup : Save the Model initialization setup dictionary.
+    smash.io.read_setup : Read the Model initialization setup dictionary.
+    smash.factory.generate_mesh : Automatic mesh generation.
+    smash.io.save_mesh : Save the Model initialization mesh dictionary.
+    smash.io.read_mesh : Read the Model initialization mesh dictionary.
+
+    Examples
+    --------
+    >>> from smash.factory import load_dataset
+    >>> setup, mesh = load_dataset("cance")
+    >>> model = smash.Model(setup, mesh)
+    </> Reading precipitation: 100%|█████████| 1440/1440 [00:00<00:00, 10512.83it/s]
+    </> Reading daily interannual pet: 100%|███| 366/366 [00:00<00:00, 13638.56it/s]
+    </> Disaggregating daily interannual pet: 100%|█| 1440/1440 [00:00<00:00, 129442
+    """
+        
     def __init__(self, setup: dict | None, mesh: dict | None):
         if setup and mesh:
             if isinstance(setup, dict):
@@ -100,6 +132,13 @@ class Model(object):
 
     @property
     def setup(self):
+
+        """
+        The setup used to create the Model object.
+
+        TODO: Fill
+        """
+
         return self._setup
 
     @setup.setter
@@ -108,6 +147,13 @@ class Model(object):
 
     @property
     def mesh(self):
+
+        """
+        The mesh used to create the Model object.
+
+        TODO: Fill
+        """
+
         return self._mesh
 
     @mesh.setter
@@ -116,6 +162,13 @@ class Model(object):
 
     @property
     def obs_response(self):
+
+        """
+        Observation response data.
+
+        TODO: Fill
+        """
+
         return self._input_data.obs_response
 
     @obs_response.setter
@@ -124,6 +177,13 @@ class Model(object):
 
     @property
     def physio_data(self):
+
+        """
+        Physiographic data.
+
+        TODO: Fill
+        """
+
         return self._input_data.physio_data
 
     @physio_data.setter
@@ -132,6 +192,13 @@ class Model(object):
 
     @property
     def atmos_data(self):
+
+        """
+        Atmospheric and meteorological data.
+
+        TODO: Fill
+        """
+
         return self._input_data.atmos_data
 
     @atmos_data.setter
@@ -140,6 +207,13 @@ class Model(object):
 
     @property
     def opr_parameters(self):
+
+        """
+        Get operator parameters for the actual structure of the Model.
+
+        TODO: Fill
+        """
+        
         return self._parameters.opr_parameters
 
     @opr_parameters.setter
@@ -148,6 +222,13 @@ class Model(object):
 
     @property
     def opr_initial_states(self):
+
+        """
+        Get operator initial states for the actual structure of the Model.
+
+        TODO: Fill
+        """
+                
         return self._parameters.opr_initial_states
 
     @opr_initial_states.setter
@@ -156,6 +237,13 @@ class Model(object):
 
     @property
     def sim_response(self):
+
+        """
+        Simulated response data.
+
+        TODO: Fill
+        """
+
         return self._output.sim_response
 
     @sim_response.setter
@@ -164,6 +252,13 @@ class Model(object):
 
     @property
     def opr_final_states(self):
+
+        """
+        Get operator final states for the actual structure of the Model.
+
+        TODO: Fill
+        """
+
         return self._output.opr_final_states
 
     @opr_final_states.setter
@@ -171,39 +266,178 @@ class Model(object):
         self._output.opr_final_states = value
 
     def copy(self):
+
+        """
+        Make a deepcopy of the Model.
+
+        Returns
+        -------
+        Model
+            A copy of Model.
+
+        Examples
+        --------
+        TODO: Fill
+        """
+
         return self.__copy__()
 
     def get_opr_parameters(self, key: str):
+
+        """
+        Get the values of an operator model parameter.
+
+        Parameters
+        ----------
+        key : str
+            The name of the operator parameter.
+
+        Returns
+        -------
+        value : np.ndarray
+            A 2D-array representing the values of the operator parameter.
+
+        Examples
+        --------
+        TODO: Fill
+
+        See Also
+        --------
+        Model.opr_parameters : Get operator parameters for the actual structure of the Model.
+        """
+        
         key = _standardize_get_opr_parameters_args(self, key)
         ind = np.argwhere(self._parameters.opr_parameters.keys == key).item()
 
         return self._parameters.opr_parameters.values[..., ind]
 
     def set_opr_parameters(self, key: str, value: Numeric | np.ndarray):
+
+        """
+        Set the values for an operator model parameter.
+
+        Parameters
+        ----------
+        key : str
+            The name of the operator parameter.
+
+        value : Numeric or np.ndarray
+            The values to set for the operator parameter.
+
+        Examples
+        --------
+        TODO: Fill
+
+        See Also
+        --------
+        Model.opr_parameters : Get operator parameters for the actual structure of the Model.
+        """
+
         key, value = _standardize_set_opr_parameters_args(self, key, value)
         ind = np.argwhere(self._parameters.opr_parameters.keys == key).item()
 
         self._parameters.opr_parameters.values[..., ind] = value
 
     def get_opr_initial_states(self, key: str):
+
+        """
+        Get the values of an operator model initial state.
+
+        Parameters
+        ----------
+        key : str
+            The name of the operator initial state.
+
+        Returns
+        -------
+        value : np.ndarray
+            A 2D-array representing the values of the operator initial state.
+
+        Examples
+        --------
+        TODO: Fill
+
+        See Also
+        --------
+        Model.opr_initial_states : Get operator initial states for the actual structure of the Model.
+        """
+
         key = _standardize_get_opr_initial_states_args(self, key)
         ind = np.argwhere(self._parameters.opr_initial_states.keys == key).item()
 
         return self._parameters.opr_initial_states.values[..., ind]
 
     def set_opr_initial_states(self, key: str, value: Numeric | np.ndarray):
+
+        """
+        Set the values for an operator model initial state.
+
+        Parameters
+        ----------
+        key : str
+            The name of the operator initial state.
+
+        value : Numeric or np.ndarray
+            The values to set for the operator initial state.
+
+        Examples
+        --------
+        TODO: Fill
+
+        See Also
+        --------
+        Model.opr_initial_states : Get operator initial states for the actual structure of the Model.
+        """
+
         key, value = _standardize_set_opr_initial_states_args(self, key, value)
         ind = np.argwhere(self._parameters.opr_initial_states.keys == key).item()
 
         self._parameters.opr_initial_states.values[..., ind] = value
 
     def get_opr_final_states(self, key: str):
+
+        """
+        Get the values of an operator model final state.
+
+        Parameters
+        ----------
+        key : str
+            The name of the operator final state.
+
+        Returns
+        -------
+        value : np.ndarray
+            A 2D-array representing the values of the operator final state.
+
+        Examples
+        --------
+        TODO: Fill
+
+        See Also
+        --------
+        Model.opr_final_states : Get operator final states for the actual structure of the Model.
+        """
+
         key = _standardize_get_opr_final_states_args(self, key)
         ind = np.argwhere(self._output.opr_final_states.keys == key).item()
 
         return self._output.opr_final_states.values[..., ind]
 
     def get_opr_parameters_bounds(self):
+
+        """
+        Get the boundary condition for the operator model parameters.
+
+        Returns
+        -------
+        bounds : dict
+            A dictionary representing the boundary condition for each operator parameter in the actual structure of the Model.
+
+        Examples
+        --------
+        TODO: Fill
+        """
+
         return {
             key: value
             for key, value in DEFAULT_BOUNDS_OPR_PARAMETERS.items()
@@ -211,6 +445,20 @@ class Model(object):
         }
 
     def get_opr_initial_states_bounds(self):
+
+        """
+        Get the boundary condition for the operator model initial states.
+
+        Returns
+        -------
+        bounds : dict
+            A dictionary representing the boundary condition for each operator initial state in the actual structure of the Model.
+
+        Examples
+        --------
+        TODO: Fill
+        """    
+
         return {
             key: value
             for key, value in DEFAULT_BOUNDS_OPR_INITIAL_STATES.items()
@@ -222,6 +470,13 @@ class Model(object):
         cost_options: dict | None = None,
         common_options: dict | None = None,
     ):
+        
+        """
+        Run the forward Model.
+
+        TODO: Fill
+        """
+
         args_options = [deepcopy(arg) for arg in [cost_options, common_options]]
 
         args = _standardize_forward_run_args(self, *args_options)
@@ -236,6 +491,13 @@ class Model(object):
         cost_options: dict | None = None,
         common_options: dict | None = None,
     ):
+
+        """
+        Model assimilation using numerical optimization algorithms.
+
+        TODO: Fill
+        """
+
         args_options = [
             deepcopy(arg) for arg in [optimize_options, cost_options, common_options]
         ]
@@ -252,9 +514,16 @@ class Model(object):
     def multiset_estimate(
         self,
         multiset: MultipleForwardRun | MultipleOptimize,
-        alpha: Numeric | ListLike = np.linspace(-2, 10, 50),
+        alpha: Numeric | ListLike | None = None,
         common_options: dict | None = None,
     ):
+        
+        """
+        Model assimilation using a Bayesian-like estimation method with multiple sets of operator parameters or/and initial states.
+
+        TODO: Fill
+        """
+        
         arg_options = deepcopy(common_options)
 
         args = _standardize_multiset_estimate_args(multiset, alpha, arg_options)

--- a/smash/core/signal_analysis/metrics/metrics.py
+++ b/smash/core/signal_analysis/metrics/metrics.py
@@ -55,7 +55,7 @@ def metrics(
 
     Examples
     --------
-
+    TODO: Fill
     """
     metric, end_warmup = _standardize_metrics_args(metric, end_warmup, model.setup)
 

--- a/smash/core/signal_analysis/prcp_indices/prcp_indices.py
+++ b/smash/core/signal_analysis/prcp_indices/prcp_indices.py
@@ -22,12 +22,6 @@ class PrecipitationIndices(dict):
     -----
     This class is essentially a subclass of dict with attribute accessors.
 
-    Attributes
-    ----------
-    TODO FC: Fill
-
-    See Also
-    --------
     TODO FC: Fill
 
     """
@@ -62,7 +56,18 @@ def precipitation_indices(
     model: Model,
 ):
     """
+    Compute precipitation indices of the Model.
+    
     TODO FC: Fill
+
+    Returns
+    -------
+    res : PrecipitationIndices
+        The generated samples result represented as a `PrecipitationIndices` object.
+
+    See Also
+    --------
+    PrecipitationIndices: Represents precipitation indices computation result.
     """
 
     # % Initialise result

--- a/smash/core/signal_analysis/segmentation/segmentation.py
+++ b/smash/core/signal_analysis/segmentation/segmentation.py
@@ -31,7 +31,7 @@ def hydrograph_segmentation(
     Compute segmentation information of flood events over all catchments of the Model.
 
     .. hint::
-        See the :ref:`User Guide <user_guide.in_depth.hydrograph_segmentation>` and :ref:`Math / Num Documentation <math_num_documentation.signal_analysis.hydrograph_segmentation>` for more.
+        See the (TODO: Fill) for more.
 
     Parameters
     ----------
@@ -79,7 +79,6 @@ def hydrograph_segmentation(
     2  V3517010 2014-11-03 08:00:00 ... 2014-11-04 16:00:00  autumn
 
     [3 rows x 6 columns]
-
     """
 
     peak_quant, max_duration, by = _standardize_hydrograph_segmentation_args(

--- a/smash/core/signal_analysis/signatures/signatures.py
+++ b/smash/core/signal_analysis/signatures/signatures.py
@@ -44,7 +44,7 @@ class Signatures(dict):
 
     See Also
     --------
-    Model.signatures: Compute continuous or/and flood event signatures of the Model.
+    smash.signatures: Compute simulated or observed hydrological signatures of the Model.
 
     """
 
@@ -81,10 +81,10 @@ def signatures(
     domain: str = "obs",
 ):
     """
-    Compute continuous or/and flood event signatures of the Model.
+    Compute simulated or observed hydrological signatures of the Model.
 
     .. hint::
-        See the :ref:`User Guide <user_guide.in_depth.signatures.computation>` and :ref:`Math / Num Documentation <math_num_documentation.signal_analysis.hydrological_signatures>` for more.
+        See the (TODO: Fill) for more.
 
     Parameters
     ----------
@@ -110,7 +110,7 @@ def signatures(
         - 'max_duration'
         - 'by'
 
-        See `smash.Model.event_segmentation` for more.
+        See `smash.hydrograph_segmentation` for more.
 
         .. note::
             If not given in case flood signatures are computed, the default values will be set for these parameters.
@@ -126,29 +126,7 @@ def signatures(
 
     Examples
     --------
-    >>> setup, mesh = smash.load_dataset("cance")
-    >>> model = smash.Model(setup, mesh)
-    >>> model.run(inplace=True)
-
-    Compute all observed and simulated signatures:
-
-    >>> res = model.signatures()
-    >>> res.cont["obs"]  # observed continuous signatures
-            code       Crc     Crchf  ...   Cfp50      Cfp90
-    0  V3524010  0.516207  0.191349  ...  3.3225  42.631802
-    1  V3515010  0.509180  0.147217  ...  1.5755  10.628400
-    2  V3517010  0.514302  0.148364  ...  0.3235   2.776700
-
-    [3 rows x 9 columns]
-
-    >>> res.event["sim"]  # simulated flood event signatures
-            code  season               start  ...  Elt         Epf
-    0  V3524010  autumn 2014-11-03 03:00:00  ...    3  106.190651
-    1  V3515010  autumn 2014-11-03 10:00:00  ...    0   21.160324
-    2  V3517010  autumn 2014-11-03 08:00:00  ...    1   5.613392
-
-    [3 rows x 12 columns]
-
+    TODO
     """
 
     cs, es, domain, event_seg = _standardize_signatures_args(sign, domain, event_seg)

--- a/smash/core/simulation/estimate/_standardize.py
+++ b/smash/core/simulation/estimate/_standardize.py
@@ -42,24 +42,28 @@ def _standardize_multiset_estimate_multiset(
 
 
 def _standardize_multiset_estimate_alpha(
-    alpha: Numeric | ListLike,
+    alpha: Numeric | ListLike | None,
 ) -> float | np.ndarray:
-    if isinstance(alpha, (int, float, list, tuple, np.ndarray)):
-        alpha = np.array(alpha, ndmin=0)
+    if alpha is None:
+        alpha = np.linspace(-2, 10, 50)
+    
+    else:
+        if isinstance(alpha, (int, float, list, tuple, np.ndarray)):
+            alpha = np.array(alpha, ndmin=0)
 
-        if not (alpha.dtype == int or alpha.dtype == float):
-            raise TypeError("All values in alpha must be of Numeric type (int, float)")
+            if not (alpha.dtype == int or alpha.dtype == float):
+                raise TypeError("All values in alpha must be of Numeric type (int, float)")
 
-        if alpha.ndim > 1:
-            raise ValueError(f"alpha must be a one-dimensional list-like array")
+            if alpha.ndim > 1:
+                raise ValueError(f"alpha must be a one-dimensional list-like array")
+
+            else:
+                if alpha.size == 1:
+                    alpha = float(alpha)
 
         else:
-            if alpha.size == 1:
-                alpha = float(alpha)
-
-    else:
-        raise TypeError(
-            "alpha must be a Numeric or ListLike type (List, Tuple, np.ndarray)"
-        )
+            raise TypeError(
+                "alpha must be a Numeric or ListLike type (List, Tuple, np.ndarray)"
+            )
 
     return alpha

--- a/smash/core/simulation/estimate/_tools.py
+++ b/smash/core/simulation/estimate/_tools.py
@@ -171,5 +171,5 @@ def _lcurve_forward_run_with_estimated_parameters(
     )
 
     return dict(
-        zip(["mahal_dist", "cost", "alpha_opt"], [l_mahal_distance, l_cost, alpha_opt])
+        zip(["mahal_dist", "cost", "alpha", "alpha_opt"], [l_mahal_distance, l_cost, alpha, alpha_opt])
     )

--- a/smash/core/simulation/estimate/estimate.py
+++ b/smash/core/simulation/estimate/estimate.py
@@ -23,9 +23,21 @@ __all__ = ["multiset_estimate"]
 def multiset_estimate(
     model: Model,
     multiset: MultipleForwardRun | MultipleOptimize,
-    alpha: Numeric | ListLike = np.linspace(-2, 10, 50),
+    alpha: Numeric | ListLike | None = None,
     common_options: dict | None = None,
 ):
+    
+    """
+    Model assimilation using a Bayesian-like estimation method with multiple sets of operator parameters or/and initial states.
+
+    TODO: Fill
+
+    Returns
+    -------
+    ret_model : Model
+        The optimized Model.
+    """
+
     wmodel = model.copy()
 
     wmodel.multiset_estimate(multiset, alpha, common_options)

--- a/smash/core/simulation/optimize/optimize.py
+++ b/smash/core/simulation/optimize/optimize.py
@@ -32,12 +32,6 @@ class MultipleOptimize(dict):
     -----
     This class is essentially a subclass of dict with attribute accessors.
 
-    Attributes
-    ----------
-    TODO FC: Fill
-
-    See Also
-    --------
     TODO FC: Fill
 
     """
@@ -76,6 +70,18 @@ def optimize(
     cost_options: dict | None = None,
     common_options: dict | None = None,
 ):
+    
+    """
+    Model assimilation using numerical optimization algorithms.
+
+    TODO: Fill
+
+    Returns
+    -------
+    ret_model : Model
+        The optimized Model.
+    """
+
     wmodel = model.copy()
 
     wmodel.optimize(mapping, optimizer, optimize_options, cost_options, common_options)
@@ -222,6 +228,18 @@ def multiple_optimize(
     cost_options: dict | None = None,
     common_options: dict | None = None,
 ) -> MultipleOptimize:
+    
+    """
+    Optimize the Model on multiple sets of operator parameters or/and initial states.
+
+    TODO: Fill
+
+    Returns
+    -------
+    mopt : MultipleOptimize
+        The multiple optimize results represented as a `MultipleOptimize` object.
+    """
+
     args_options = [
         deepcopy(arg) for arg in [optimize_options, cost_options, common_options]
     ]

--- a/smash/core/simulation/options.py
+++ b/smash/core/simulation/options.py
@@ -20,6 +20,13 @@ def default_optimize_options(
     mapping: str = "uniform",
     optimizer: str | None = None,
 ) -> dict:
+    
+    """
+    Get the default optimization options.
+
+    TODO: Fill
+    """
+    
     mapping, optimizer = _standardize_default_optimize_options_args(mapping, optimizer)
 
     return _standardize_simulation_optimize_options(model, mapping, optimizer, None)
@@ -27,4 +34,11 @@ def default_optimize_options(
 
 # % TODO: add docstring - this function is used for creating and the documentation of cost_options in model.optimize()
 def default_cost_options(model: Model) -> dict:
+
+    """
+    Get the default cost computation options.
+
+    TODO: Fill
+    """
+        
     return _standardize_simulation_cost_options(model, None)

--- a/smash/core/simulation/run/run.py
+++ b/smash/core/simulation/run/run.py
@@ -31,12 +31,6 @@ class MultipleForwardRun(dict):
     -----
     This class is essentially a subclass of dict with attribute accessors.
 
-    Attributes
-    ----------
-    TODO FC: Fill
-
-    See Also
-    --------
     TODO FC: Fill
 
     """
@@ -72,6 +66,18 @@ def forward_run(
     cost_options: dict | None = None,
     common_options: dict | None = None,
 ) -> Model:
+    
+    """
+    Run the forward Model.
+
+    TODO: Fill
+
+    Returns
+    -------
+    ret_model : Model
+        The Model with forward run outputs.
+    """
+
     wmodel = model.copy()
 
     wmodel.forward_run(cost_options, common_options)
@@ -120,6 +126,18 @@ def multiple_forward_run(
     cost_options: dict | None = None,
     common_options: dict | None = None,
 ) -> MultipleForwardRun:
+    
+    """
+    Run the forward Model on multiple sets of operator parameters or/and initial states.
+
+    TODO: Fill
+
+    Returns
+    -------
+    mfr : MultipleForwardRun
+        The multiple forward run results represented as a `MultipleForwardRun` object.
+    """
+    
     args_options = [deepcopy(arg) for arg in [cost_options, common_options]]
 
     args = _standardize_multiple_forward_run_args(model, samples, *args_options)

--- a/smash/factory/mesh/mesh.py
+++ b/smash/factory/mesh/mesh.py
@@ -38,7 +38,7 @@ def generate_mesh(
     Automatic mesh generation.
 
     .. hint::
-        See the :ref:`User Guide <user_guide.in_depth.automatic_meshing>` for more.
+        See the (TODO: Fill) for more.
 
     Parameters
     ----------
@@ -86,7 +86,7 @@ def generate_mesh(
         the given catchment area and the modeled catchment area calculated from the flow directions file.
         This can be generalized to :math:`n`.
 
-        .. image:: ../../_static/max_depth.png
+        .. image:: ../../../_static/max_depth.png
             :align: center
             :width: 350
 
@@ -99,11 +99,11 @@ def generate_mesh(
     Returns
     -------
     dict
-        A mesh dictionary that can be used to initialize the `Model` object.
+        A mesh dictionary that can be used to initialize the `smash.Model` object.
 
     See Also
     --------
-    Model: Primary data structure of the hydrological model `smash`.
+    smash.Model: Primary data structure of the hydrological model `smash`.
 
     Examples
     --------

--- a/smash/factory/net/net.py
+++ b/smash/factory/net/net.py
@@ -159,10 +159,10 @@ class Net(object):
             .. hint::
                 See options for each layer type:
 
-                - 'dense' :ref:`(see here) <api_reference.add_dense>`
-                - 'activation' :ref:`(see here) <api_reference.add_activation>`
-                - 'scale' :ref:`(see here) <api_reference.add_scale>`
-                - 'dropout' :ref:`(see here) <api_reference.add_dropout>`
+                - 'dense' :ref:`(see here) <api_reference.sub-packages.net.add_dense>`
+                - 'activation' :ref:`(see here) <api_reference.sub-packages.net.add_activation>`
+                - 'scale' :ref:`(see here) <api_reference.sub-packages.net.add_scale>`
+                - 'dropout' :ref:`(see here) <api_reference.sub-packages.net.add_dropout>`
 
         Examples
         --------

--- a/smash/factory/samples/samples.py
+++ b/smash/factory/samples/samples.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from smash._typing import Numeric
 
 
-__all__ = ["generate_samples", "Samples"]
+__all__ = ["Samples", "generate_samples"]
 
 
 class Samples(dict):
@@ -42,7 +42,7 @@ class Samples(dict):
 
     See Also
     --------
-    smash.generate_samples: Generate a multiple set of spatially uniform Model parameters/states.
+    smash.factory.generate_samples: Generate a multiple set of spatially uniform Model parameters/states.
 
     Examples
     --------
@@ -307,11 +307,11 @@ def generate_samples(
     Returns
     -------
     res : Samples
-        The generated samples result represented as a `Samples` object.
+        The generated samples result represented as a `smash.Samples` object.
 
     See Also
     --------
-    Samples: Represents the generated samples using `smash.generate_samples` method.
+    smash.Samples: Represents the generated samples using `smash.factory.generate_samples` method.
 
     Examples
     --------

--- a/smash/io/mesh/mesh.py
+++ b/smash/io/mesh/mesh.py
@@ -14,7 +14,7 @@ __all__ = ["save_mesh", "read_mesh"]
 
 def save_mesh(mesh: dict, path: str):
     """
-    Save Model initialization mesh dictionary.
+    Save the Model initialization mesh dictionary.
 
     Parameters
     ----------
@@ -26,10 +26,11 @@ def save_mesh(mesh: dict, path: str):
 
     See Also
     --------
-    read_mesh: Read Model initialization mesh dictionary.
+    smash.io.read_mesh: Read the Model initialization mesh dictionary.
 
     Examples
     --------
+    >>> import smash
     >>> setup, mesh = smash.factory.load_dataset("cance")
     >>> mesh
     {'dx': 1000.0, 'nac': 383, 'ncol': 28, 'ng': 3, 'nrow': 28 ...}
@@ -55,7 +56,7 @@ def save_mesh(mesh: dict, path: str):
 
 def read_mesh(path: str) -> dict:
     """
-    Read Model initialization mesh dictionary.
+    Read the Model initialization mesh dictionary.
 
     Parameters
     ----------
@@ -76,10 +77,11 @@ def read_mesh(path: str) -> dict:
 
     See Also
     --------
-    save_mesh: Save Model initialization mesh dictionary.
+    smash.io.save_mesh: Save the Model initialization mesh dictionary.
 
     Examples
     --------
+    >>> import smash
     >>> setup, mesh = smash.factory.load_dataset("cance")
     >>> mesh
     {'dx': 1000.0, 'nac': 383, 'ncol': 28, 'ng': 3, 'nrow': 28 ...}

--- a/smash/io/model/model.py
+++ b/smash/io/model/model.py
@@ -17,7 +17,6 @@ from smash.io.model._parse import (
 import os
 import errno
 import h5py
-import pandas as pd
 
 from typing import TYPE_CHECKING
 
@@ -29,7 +28,7 @@ __all__ = ["save_model", "read_model"]
 
 def save_model(model: Model, path: str):
     """
-    Save Model object.
+    Save the Model object.
 
     Parameters
     ----------
@@ -41,11 +40,12 @@ def save_model(model: Model, path: str):
 
     See Also
     --------
-    read_model: Read Model object.
-    Model: Primary data structure of the hydrological model `smash`.
+    smash.io.read_model: Read the Model object.
+    smash.Model: Primary data structure of the hydrological model `smash`.
 
     Examples
     --------
+    >>> import smash
     >>> setup, mesh = smash.factory.load_dataset("cance")
     >>> model = smash.Model(setup, mesh)
 
@@ -85,7 +85,7 @@ def save_model(model: Model, path: str):
 # % TODO: enhance Model initialization, using setup and mesh which ara not None (disable read data in setup)
 def read_model(path: str) -> Model:
     """
-    Read Model object.
+    Read the Model object.
 
     Parameters
     ----------
@@ -95,7 +95,7 @@ def read_model(path: str) -> Model:
     Returns
     -------
     Model :
-        A Model object loaded from HDF5 file.
+        The Model object loaded from HDF5 file.
 
     Raises
     ------
@@ -106,11 +106,12 @@ def read_model(path: str) -> Model:
 
     See Also
     --------
-    save_model: Save Model object.
-    Model: Primary data structure of the hydrological model `smash`.
+    smash.io.save_model: Save the Model object.
+    smash.Model: Primary data structure of the hydrological model `smash`.
 
     Examples
     --------
+    >>> import smash
     >>> setup, mesh = smash.factory.load_dataset("cance")
     >>> model = smash.Model(setup, mesh)
 

--- a/smash/io/setup/setup.py
+++ b/smash/io/setup/setup.py
@@ -9,7 +9,7 @@ __all__ = ["save_setup", "read_setup"]
 
 def save_setup(setup: dict, path: str):
     """
-    Save Model initialization setup dictionary.
+    Save the Model initialization setup dictionary.
 
     Parameters
     ----------
@@ -21,10 +21,11 @@ def save_setup(setup: dict, path: str):
 
     See Also
     --------
-    read_setup: Read Model initialization setup dictionary.
+    smash.io.read_setup: Read the Model initialization setup dictionary.
 
     Examples
     --------
+    >>> import smash
     >>> setup, mesh = smash.factory.load_dataset("cance")
     >>> setup
     {'structure': 'gr-a-lr', 'dt': 3600, 'start_time': '2014-09-15 00:00', ...}
@@ -49,7 +50,7 @@ def save_setup(setup: dict, path: str):
 
 def read_setup(path: str) -> dict:
     """
-    Read Model initialization setup dictionary.
+    Read the Model initialization setup dictionary.
 
     Parameters
     ----------
@@ -63,10 +64,11 @@ def read_setup(path: str) -> dict:
 
     See Also
     --------
-    save_setup: Save Model initialization setup dictionary.
+    smash.io.save_setup: Save the Model initialization setup dictionary.
 
     Examples
     --------
+    >>> import smash
     >>> setup, mesh = smash.factory.load_dataset("cance")
     >>> setup
     {'structure': 'gr-a-lr', 'dt': 3600, 'start_time': '2014-09-15 00:00', ...}


### PR DESCRIPTION
Start the API documentation:
- New doc structure
- Sub-directory for each principal section

Code:
- makefile doc: find and recursively remove smash/ directory generated by make doc
- gen rst file: capitalize words separated by "_"
- custom options directive: fix new links to Net and Model
- multiset estimate: change default value of alpha to None for simplifying the documentation.